### PR TITLE
Fix issue with duplicate input on some Android devices

### DIFF
--- a/src/screens/WorkspaceChat/PromptInput/index.tsx
+++ b/src/screens/WorkspaceChat/PromptInput/index.tsx
@@ -224,10 +224,13 @@ export default function PromptInput({ attachmentHandler }: PromptInputProps) {
           borderTopRightRadius: 30,
         }}>
         <Animated.View
+          key="primaryPromptInputContainer"
           ref={inputRef}
           style={{ paddingTop: paddingAnim }}
           className={"flex flex-col justify-between"}>
           <BottomSheetTextInput
+            key="primaryPromptInput"
+            keyboardType="default"
             multiline={true}
             placeholder={
               hasModelSelected
@@ -250,7 +253,7 @@ export default function PromptInput({ attachmentHandler }: PromptInputProps) {
               bottomSheetRef.current?.snapToIndex(0);
               Keyboard.dismiss();
             }}
-            value={chatHandler.prompt}
+            defaultValue={chatHandler.prompt}
             onChangeText={handleTextInputChange}
             onSelectionChange={event => setSelection(event.nativeEvent.selection)}
             selection={selection}


### PR DESCRIPTION
On some devices, the OSK on Android will double input the user text while actively typing. It only happens on some QRD handhelds.

Seems like adding keys to prompt input but also
```
 defaultValue={chatHandler.prompt}
 // value={chatHandler.prompt}
 ```
Seems to resove this behavior and pasting still seems to work as designed.