### PR TITLE
Disable tool calling in ollama models that do not support tools

### DIFF
--- a/src/screens/UserSettings/AdvancedModelPreferences/providers/OllamaOptions/index.tsx
+++ b/src/screens/UserSettings/AdvancedModelPreferences/providers/OllamaOptions/index.tsx
@@ -90,7 +90,8 @@ export default function OllamaOptions({
         let provider = new OllamaProvider({ provider: 'ollama', config: { baseURL: currentBaseUrl, model: currentModelId } });
         const details = await provider.getModelDetails({ baseUrl: currentBaseUrl, modelTag: currentModelId });
         if (!details) return;
-        setNoToolCalls(details?.capabilities?.includes('tools') === false)
+        const supportsToolCalls = details?.capabilities?.includes('tools') || false
+        setNoToolCalls(supportsToolCalls === false)
       } catch { return; }
     }
     checkModelCapability()

--- a/src/screens/UserSettings/AdvancedModelPreferences/providers/OllamaOptions/index.tsx
+++ b/src/screens/UserSettings/AdvancedModelPreferences/providers/OllamaOptions/index.tsx
@@ -4,7 +4,7 @@ import { screenDimensions } from '@/utils/constants';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import useKeyboardHeight from '@/hooks/useKeyboardHeight';
 import { BottomSheetModal, BottomSheetBackdrop, BottomSheetView } from '@gorhom/bottom-sheet';
-import { X, MagnifyingGlass, CaretDown } from 'phosphor-react-native';
+import { X, MagnifyingGlass, CaretDown, Warning } from 'phosphor-react-native';
 import getLLM from '@/utils/AiProviders';
 import OllamaProvider, { OllamaModel } from '@/utils/AiProviders/OllamaProvider';
 import debounce from 'lodash/debounce';
@@ -27,6 +27,7 @@ export default function OllamaOptions({
   const [currentBaseUrl, setCurrentBaseUrl] = useState(baseUrl || '');
   const [currentModelId, setCurrentModelId] = useState(model || '');
   const [searchQuery, setSearchQuery] = useState('');
+  const [noToolCalls, setNoToolCalls] = useState(false);
   const [availableModels, setAvailableModels] = useState<OllamaModel[]>([]);
   const bottomSheetRef = useRef<BottomSheetModal>(null);
 
@@ -82,6 +83,19 @@ export default function OllamaOptions({
     };
   }, [debouncedFetchModels, debouncedSaveBaseUrl]);
 
+  useEffect(() => {
+    async function checkModelCapability() {
+      try {
+        if (!currentBaseUrl || !currentModelId) return;
+        let provider = new OllamaProvider({ provider: 'ollama', config: { baseURL: currentBaseUrl, model: currentModelId } });
+        const details = await provider.getModelDetails({ baseUrl: currentBaseUrl, modelTag: currentModelId });
+        if (!details) return;
+        setNoToolCalls(details?.capabilities?.includes('tools') === false)
+      } catch { return; }
+    }
+    checkModelCapability()
+  }, [currentModelId, currentBaseUrl])
+
   return (
     <View className="flex flex-col">
       <KeyboardAvoidingView style={{ gap: 8 }} behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1 flex flex-col">
@@ -113,6 +127,26 @@ export default function OllamaOptions({
         </View>
 
         <View className="w-full flex flex-col" style={{ gap: 12 }}>
+          {noToolCalls === true && (
+            <View className="flex flex-row items-start w-full justify-start">
+              <View className="rounded-lg flex flex-row items-center w-full" style={[{
+                paddingHorizontal: 14,
+                paddingVertical: 10,
+                gap: 4,
+                borderWidth: 1,
+                borderColor: '#F97066',
+                maxWidth: '100%',
+                backgroundColor: 'rgba(122,39,26,0.2)'
+              }]}>
+                <Warning size={18} color="#F97066" />
+                <Text style={{ color: '#F97066' }} className="text-xs">
+                  This model was detected to have <Text style={{ fontWeight: 800, textDecorationLine: 'underline' }}>no tool calling support</Text>.
+                  Only simple chat + RAG will be supported
+                </Text>
+              </View>
+            </View>
+          )}
+
           <View className="flex flex-row items-center justify-between">
             <Text style={{ color: '#9F9FA0' }} className="text-lg uppercase">Model Selection</Text>
           </View>

--- a/src/utils/AiProviders/OllamaProvider/index.ts
+++ b/src/utils/AiProviders/OllamaProvider/index.ts
@@ -1,4 +1,4 @@
-import BaseOpenAILikeProvider from "../baseOpenAILikeProvider";
+import BaseOpenAILikeProvider, { IStreamableResponse } from "../baseOpenAILikeProvider";
 import OpenAILite from "@/utils/openai";
 
 export interface OllamaProviderConfig {
@@ -30,6 +30,7 @@ function ollamaBaseURLFormatter(baseURL?: string) {
 class OllamaProvider extends BaseOpenAILikeProvider {
   private baseURL: string = '';
   private apiKey: string | null = null;
+  private modelCapabilities: { [modelName: string]: { tools: boolean } } = {};
 
   public model: string;
   private connectionProvider: string;
@@ -84,6 +85,62 @@ class OllamaProvider extends BaseOpenAILikeProvider {
    */
   async unloadModel() {
     return;
+  }
+
+  private async checkToolSupport(): Promise<boolean> {
+    // Check cache if exists
+    if (this.modelCapabilities[this.model]?.tools !== undefined) {
+      return this.modelCapabilities[this.model].tools;
+    }
+
+    try {
+      const url = new URL(this.baseURL);
+      const apiBaseUrl = url.origin;
+      const response = await fetch(`${apiBaseUrl}/api/show`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ model: this.model }),
+      });
+
+      if (!response.ok) {
+        this.log(`Failed to fetch model details for ${this.model}. Assuming no tool support.`);
+        this.modelCapabilities[this.model] = { tools: false };
+        return false;
+      }
+
+      const data = await response.json();
+      const hasToolSupport = Array.isArray(data.capabilities) && data.capabilities.includes('tools');
+
+      this.log(`Model ${this.model} tool support: ${hasToolSupport}`);
+      this.modelCapabilities[this.model] = { tools: hasToolSupport };
+      return hasToolSupport;
+    } catch (error) {
+      this.log(`Error checking tool support for ${this.model}:`, error);
+      this.modelCapabilities[this.model] = { tools: false };
+      return false;
+    }
+  }
+
+  /*
+   * Override for streamGetChatCompletion to check if the model supports tools.
+   *
+   * In Ollama, some models support tools so we need to check via the API
+   * to see if the model supports tools. We must remove the tools from the request
+   * if the model does not support tools or else Ollama will throw an error.
+  */
+  override async streamGetChatCompletion(messages: any[] = [], availableTools: any[] = []): Promise<IStreamableResponse> {
+    const hasToolSupport = await this.checkToolSupport();
+    const tools = hasToolSupport ? availableTools : [];
+
+    if (!hasToolSupport && availableTools.length > 0) {
+      this.log(`Model ${this.model} does not support tools, removing them from request.`);
+    } else {
+      this.log(`Model ${this.model} supports tools, adding them to request.`);
+    }
+
+    return super.streamGetChatCompletion(messages, tools);
   }
 }
 

--- a/src/utils/AiProviders/OllamaProvider/index.ts
+++ b/src/utils/AiProviders/OllamaProvider/index.ts
@@ -131,11 +131,7 @@ class OllamaProvider extends BaseOpenAILikeProvider {
     try {
       const modelTagDetails = await this.getModelDetails({ baseUrl: this.baseURL, modelTag: this.model });
       if (!modelTagDetails) throw new Error('Could not fetch tag details for model')
-      const hasToolSupport = (
-        !!modelTagDetails.capabilities &&
-        Array.isArray(modelTagDetails.capabilities) &&
-        modelTagDetails.capabilities.includes('tools'));
-
+      const hasToolSupport = modelTagDetails?.capabilities?.includes('tools') || false;
       this.modelCapabilities[this.model] = { tools: hasToolSupport };
       return hasToolSupport;
     } catch (error) {

--- a/src/utils/AiProviders/OllamaProvider/index.ts
+++ b/src/utils/AiProviders/OllamaProvider/index.ts
@@ -87,33 +87,55 @@ class OllamaProvider extends BaseOpenAILikeProvider {
     return;
   }
 
-  private async checkToolSupport(): Promise<boolean> {
-    // Check cache if exists
-    if (this.modelCapabilities[this.model]?.tools !== undefined) {
-      return this.modelCapabilities[this.model].tools;
+  /**
+   * Grabs the model details (license, capabilites, etc) from the internal Ollama API endpoint so that
+   * we can know more information about a model before using it.
+   * @param param0 
+   */
+  async getModelDetails({
+    baseUrl = this.baseURL,
+    modelTag = this.model
+  }: { baseUrl: string, modelTag: string }) {
+    try {
+      const apiBaseUrl = new URL(baseUrl).origin; // api/show is not under v1/
+      const details: null | { capabilities: string[] } = await fetch(`${apiBaseUrl}/api/show`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: modelTag }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`Failed to fetch model details for ${modelTag}. Assuming no tool support.`)
+          return res.json();
+        })
+        .catch((error) => {
+          this.log('getModelDetails', error)
+          return null;
+        })
+
+      return details;
+    } catch (error) {
+      this.log(`Error checking tag details for ${modelTag}:`, error);
+      return false;
     }
+  }
+
+  /**
+   * Check if the current model for the provider has the ability to call tools
+   * This is determined by the Ollama API and will determine if tools are passed into the model during
+   * chat completion since if we send tools Ollama will crash.
+   * @returns 
+   */
+  private async checkToolSupport(): Promise<boolean> {
+    if (this.modelCapabilities[this.model]?.tools !== undefined) return this.modelCapabilities[this.model].tools;
 
     try {
-      const url = new URL(this.baseURL);
-      const apiBaseUrl = url.origin;
-      const response = await fetch(`${apiBaseUrl}/api/show`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ model: this.model }),
-      });
+      const modelTagDetails = await this.getModelDetails({ baseUrl: this.baseURL, modelTag: this.model });
+      if (!modelTagDetails) throw new Error('Could not fetch tag details for model')
+      const hasToolSupport = (
+        !!modelTagDetails.capabilities &&
+        Array.isArray(modelTagDetails.capabilities) &&
+        modelTagDetails.capabilities.includes('tools'));
 
-      if (!response.ok) {
-        this.log(`Failed to fetch model details for ${this.model}. Assuming no tool support.`);
-        this.modelCapabilities[this.model] = { tools: false };
-        return false;
-      }
-
-      const data = await response.json();
-      const hasToolSupport = Array.isArray(data.capabilities) && data.capabilities.includes('tools');
-
-      this.log(`Model ${this.model} tool support: ${hasToolSupport}`);
       this.modelCapabilities[this.model] = { tools: hasToolSupport };
       return hasToolSupport;
     } catch (error) {
@@ -131,13 +153,10 @@ class OllamaProvider extends BaseOpenAILikeProvider {
    * if the model does not support tools or else Ollama will throw an error.
   */
   override async streamGetChatCompletion(messages: any[] = [], availableTools: any[] = []): Promise<IStreamableResponse> {
-    const hasToolSupport = await this.checkToolSupport();
-    const tools = hasToolSupport ? availableTools : [];
-
-    if (!hasToolSupport && availableTools.length > 0) {
+    let tools = availableTools;
+    if (availableTools.length > 0 && !(await this.checkToolSupport())) {
       this.log(`Model ${this.model} does not support tools, removing them from request.`);
-    } else {
-      this.log(`Model ${this.model} supports tools, adding them to request.`);
+      tools = [];
     }
 
     return super.streamGetChatCompletion(messages, tools);


### PR DESCRIPTION
- Adds a check on the `/api/show` endpoint and sees if model has `tools` as one of it's capabilities
- Caches models and if they support tool calling inside the `OllamaProvider` class
- Overloaded `streamGetChatCompletion` to dynamically add/remove tools to the OpenAI request