### PR TITLE
Context window by device mem

### DIFF
--- a/src/database/models/Workspace.ts
+++ b/src/database/models/Workspace.ts
@@ -9,6 +9,7 @@ import uiStore from '@/store/UIStore';
 import WorkspaceChat from './WorkspaceChat';
 import AnythingLLMExternal from '@/utils/AnythingLLMExternal';
 import Telemetry from '@/utils/Telemetry';
+import { getDefaultContextLength } from '@/utils/contextLength';
 
 export type WorkspaceType = {
   name: string;
@@ -47,7 +48,10 @@ export default class Workspace extends Model {
    * so no weirdness happens during inference when a workspace has no override.
    */
   static defaultTemperature = 0.7;
-  static defaultContextLength = 1024;
+  /** Scales with device RAM up to a max of 2048 - see src/utils/contextLength.ts */
+  static get defaultContextLength(): number {
+    return getDefaultContextLength();
+  }
   static maxSystemPromptLength = 10_000;
 
   static writableFields = {

--- a/src/utils/AiProviders/onDevice/llamaRn/index.ts
+++ b/src/utils/AiProviders/onDevice/llamaRn/index.ts
@@ -11,6 +11,7 @@ import { defaultModels } from '@/utils/models';
 import { stops } from '@/utils/chat';
 import { ICompleteResponse } from '@/utils/AiProviders/baseOpenAILikeProvider';
 import type OnDeviceProvider from '@/utils/AiProviders/onDevice/index';
+import { getDefaultContextLength } from '@/utils/contextLength';
 
 export type NativeLlamaChatMessage = {
   role: string;
@@ -43,7 +44,10 @@ export default class LlamaRnWrapper {
    * On overflow, the oldest chat turns are dropped before the prompt is sent (see `fitMessagesToContext`)
    * and llama.cpp context shifting is enabled as a last line of defence during generation.
    */
-  static DEFAULT_CONTEXT_LENGTH = 1024;
+  /** Scales with device RAM up to a max of 2048 - see src/utils/contextLength.ts */
+  static get DEFAULT_CONTEXT_LENGTH(): number {
+    return getDefaultContextLength();
+  }
   static DEFAULT_TEMPERATURE = 0.7;
 
   /**

--- a/src/utils/contextLength.ts
+++ b/src/utils/contextLength.ts
@@ -1,0 +1,36 @@
+import DeviceInfo from 'react-native-device-info';
+
+/** Hard ceiling for the RAM-derived default. Users can still set a higher value per workspace. */
+export const MAX_DEFAULT_CONTEXT_LENGTH = 2048;
+/** Used when device memory cannot be read. */
+export const FALLBACK_DEFAULT_CONTEXT_LENGTH = 1024;
+
+/**
+ * RAM tiers (GB, exclusive upper bound) -> default context length.
+ * Evaluated in order; devices at or above the last bound get the max.
+ */
+const RAM_TIERS: Array<[maxGb: number, contextLength: number]> = [
+  [4, 512],
+  [6, 1024],
+];
+
+let cached: number | null = null;
+
+/**
+ * Default workspace context length scaled to the device's total RAM, capped at
+ * MAX_DEFAULT_CONTEXT_LENGTH. The on-device KV cache grows with context length, so
+ * low-memory phones get a smaller default to avoid OOM during inference.
+ */
+export function getDefaultContextLength(): number {
+  if (cached !== null) return cached;
+  try {
+    const totalGb = DeviceInfo.getTotalMemorySync() / 1000 / 1000 / 1000;
+    if (!Number.isFinite(totalGb) || totalGb <= 0) throw new Error('Invalid total memory');
+    const tier = RAM_TIERS.find(([maxGb]) => totalGb < maxGb);
+    cached = Math.min(tier ? tier[1] : MAX_DEFAULT_CONTEXT_LENGTH, MAX_DEFAULT_CONTEXT_LENGTH);
+  } catch (e) {
+    console.error('Failed to read device memory for default context length:', e);
+    cached = FALLBACK_DEFAULT_CONTEXT_LENGTH;
+  }
+  return cached;
+}


### PR DESCRIPTION
Scale workspace context window by device memory: Under 4 GB gets 512, under 6 GB gets 1024, and 6 GB or more gets 2048. If the memory read fails, it falls back to 1024.