### PR TITLE
Improved Context manager for on-device

### DIFF
--- a/src/database/migrations.ts
+++ b/src/database/migrations.ts
@@ -1,7 +1,16 @@
-import { schemaMigrations } from '@nozbe/watermelondb/Schema/migrations';
+import { schemaMigrations, addColumns } from '@nozbe/watermelondb/Schema/migrations';
 
 export default schemaMigrations({
   migrations: [
-    // Initial migration is handled by the schema
+    // v1 -> v2: rolling context summary per thread (see utils/chat/contextCompaction)
+    {
+      toVersion: 2,
+      steps: [
+        addColumns({
+          table: 'workspace_threads',
+          columns: [{ name: 'context_summary', type: 'string', isOptional: true }],
+        }),
+      ],
+    },
   ],
 });

--- a/src/database/models/WorkspaceThread.ts
+++ b/src/database/models/WorkspaceThread.ts
@@ -10,6 +10,21 @@ import uiStore from '@/store/UIStore';
 import truncate from 'truncate';
 import WorkspaceChat from './WorkspaceChat';
 
+/**
+ * Rolling summary of the oldest chats in a thread, produced by `ContextCompactor` so
+ * long conversations still fit small (on-device) context windows. `throughUuid` and
+ * `coveredCount` let the compactor verify the summary still lines up with the saved
+ * chats - deleting/retrying an earlier chat makes it stale and it is rebuilt.
+ */
+export type ThreadContextSummary = {
+  summary: string;
+  /** uuid of the newest chat folded into the summary */
+  throughUuid: string;
+  /** Number of chats (user/assistant pairs), counted from the start of the thread, folded into the summary */
+  coveredCount: number;
+  updatedAt: number;
+};
+
 export type WorkspaceThreadType = {
   name: string;
   workspaceSlug: string;
@@ -56,6 +71,7 @@ export default class WorkspaceThread extends Model {
   @immutableRelation('workspaces', 'workspace_slug') workspace!: Relation<Model & WorkspaceType>;
   @field('is_remote') isRemote!: boolean;
   @json('remote_config', (json: any) => json) remoteConfig!: WorkspaceThreadType['remoteConfig'];
+  @json('context_summary', (json: any) => json) contextSummary!: ThreadContextSummary | null;
   @field('created_at') createdAt!: number;
 
   static log(message: any, ...args: any[]) {
@@ -195,6 +211,42 @@ export default class WorkspaceThread extends Model {
     } catch (error) {
       console.error('Error updating workspace thread:', error);
       return null;
+    }
+  }
+
+  /**
+   * Rolling context summary for a thread - null when none has been built yet.
+   * Not part of `WorkspaceThreadType` on purpose: it is an inference detail, not thread metadata.
+   */
+  static async getContextSummary(threadSlug: string): Promise<ThreadContextSummary | null> {
+    try {
+      const thread = (await this.get([{ field: 'slug', value: threadSlug }]))?.[0] as (Model & { contextSummary: ThreadContextSummary | null }) | undefined;
+      const summary = thread?.contextSummary ?? null;
+      if (!summary?.summary || !summary.throughUuid || !summary.coveredCount) return null;
+      return summary;
+    } catch (error) {
+      console.error('Error reading thread context summary:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Persists (or clears with `null`) the rolling context summary for a thread.
+   */
+  static async setContextSummary(threadSlug: string, summary: ThreadContextSummary | null): Promise<boolean> {
+    try {
+      const thread = (await this.get([{ field: 'slug', value: threadSlug }]))?.[0];
+      if (!thread) return false;
+      await database.write(async () => {
+        await thread.update((record: any) => {
+          record.contextSummary = summary;
+        });
+      });
+      this.log(summary ? `saved context summary for thread ${threadSlug} (${summary.coveredCount} chats)` : `cleared context summary for thread ${threadSlug}`);
+      return true;
+    } catch (error) {
+      console.error('Error saving thread context summary:', error);
+      return false;
     }
   }
 

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -1,7 +1,7 @@
 import { appSchema, tableSchema } from '@nozbe/watermelondb';
 
 export default appSchema({
-  version: 1,
+  version: 2,
   tables: [
     tableSchema({
       name: 'workspaces',
@@ -24,6 +24,8 @@ export default appSchema({
         { name: 'slug', type: 'string', isIndexed: true },
         { name: 'is_remote', type: 'boolean', isOptional: true },
         { name: 'remote_config', type: 'string', isOptional: true },
+        // Rolling summary of the oldest chats used to keep long threads inside small context windows (JSON, see ThreadContextSummary)
+        { name: 'context_summary', type: 'string', isOptional: true },
         { name: 'created_at', type: 'number' },
       ],
     }),

--- a/src/screens/WorkspaceChat/ChatHistory/Messages/Assistant/index.tsx
+++ b/src/screens/WorkspaceChat/ChatHistory/Messages/Assistant/index.tsx
@@ -14,11 +14,20 @@ import { focusMessageActions } from "../focusMessageActions";
  * straight from the list - no per-message event listeners - and is memoised so
  * only the row whose snapshot changed re-renders while a reply streams.
  */
+/**
+ * The markdown body ends with the library's default paragraph margin (10), which is what
+ * normally separates this row from the next user bubble. When actions or citations render
+ * below the text they become the last child and have no margin of their own, so the next
+ * row sits flush against them - pad the block by the same amount in that case.
+ */
+const TRAILING_CHIPS_BOTTOM_PADDING = 10;
+
 export default memo(function AssistantMessage({ chat }: { chat: DynamicChatMessage }) {
     const response = chat.response;
     const handleLongPress = () => focusMessageActions(chat, 'assistant');
+    const hasTrailingChips = !!response?.actions?.length || (!!response?.citations?.length && !chat.isLoading);
     return (
-        <View className="flex flex-col items-start w-full justify-start" style={{ gap: 11 }}>
+        <View className="flex flex-col items-start w-full justify-start" style={{ gap: 11, paddingBottom: hasTrailingChips ? TRAILING_CHIPS_BOTTOM_PADDING : 0 }}>
             <ActivityChain chat={chat} />
             {chat.type === 'error' ? (
                 <ErrorContainer message={response?.textResponse} onLongPress={handleLongPress} />

--- a/src/utils/AiProviders/baseOpenAILikeProvider/index.ts
+++ b/src/utils/AiProviders/baseOpenAILikeProvider/index.ts
@@ -19,6 +19,8 @@ interface BaseLLMProviderConfig {
 
 export type ICompleteResponse = {
   textResponse: string;
+  /** True when the reply stopped because the context window was full rather than because the model finished. */
+  truncatedByContext?: boolean;
   toolCalls?: {
     type: 'function'
     function: {
@@ -95,6 +97,18 @@ export function extractReasoningContent(messageOrDelta: any): string | undefined
     undefined
   );
 }
+
+/**
+ * The pieces of a prompt a provider may reshape before it is rendered - see `shapePrompt`.
+ */
+export type PromptShape = {
+  /** Saved chats sent verbatim, oldest first (the new user prompt is not included). */
+  history: DynamicChatMessage[];
+  /** RAG chunks that go into the system prompt. */
+  contextTexts: string[];
+  /** Summary of earlier chats that `history` no longer contains - rendered into the system prompt. */
+  summary: string | null;
+};
 
 class SilentError extends Error {
   constructor(message: string) {
@@ -214,9 +228,14 @@ export default abstract class BaseOpenAILikeProvider {
    * 
    * Will also add the context texts to the system message if they are provided.
    */
-  defaultSystemMessage(contextTexts: string[] = []) {
+  defaultSystemMessage(contextTexts: string[] = [], summary: string | null = null) {
     const baseMessage = this.workspace?.systemPrompt || BaseOpenAILikeProvider.DEFAULT_SYSTEM_MESSAGE;
-    if (!contextTexts.length) return baseMessage;
+    // The summary lives in the system prompt (rather than as a fake turn) so it survives history
+    // pruning and works with templates that require strictly alternating user/assistant roles.
+    const withSummary = summary
+      ? `${baseMessage}\n\nSummary of the conversation so far (earlier messages are not shown):\n${summary}`
+      : baseMessage;
+    if (!contextTexts.length) return withSummary;
 
     const context = contextTexts
       .map((text, i) => {
@@ -224,7 +243,16 @@ export default abstract class BaseOpenAILikeProvider {
       })
       .join("\n\n");
 
-    return `${baseMessage}\n\n[CONTEXT_START]\n${context}\n[CONTEXT_END]`;
+    return `${withSummary}\n\n[CONTEXT_START]\n${context}\n[CONTEXT_END]`;
+  }
+
+  /**
+   * Hook for providers to fit the prompt to their context window before it is rendered:
+   * swap old history for a summary, trim RAG chunks, etc. The default sends everything.
+   * `threadSlug` identifies where a provider may persist per-thread state (eg: a rolling summary).
+   */
+  protected async shapePrompt(shape: PromptShape, _options: { threadSlug: string | null; onStatus?: (status: string) => void }): Promise<PromptShape> {
+    return shape;
   }
 
   /**
@@ -254,18 +282,20 @@ export default abstract class BaseOpenAILikeProvider {
     chatHistory = [],
     userPrompt = "",
     attachments = [],
+    summary = null,
   }: {
     contextTexts: string[];
     chatHistory: DynamicChatMessage[];
     userPrompt: string;
     attachments?: IAttachment[];
+    summary?: string | null;
   }) {
     // o1 Models do not support the "system" role
     // in order to combat this, we can use the "user" role as a replacement for now
     // https://community.openai.com/t/o1-models-do-not-support-system-role-in-chat-completion/953880
     const prompt = {
       role: this.isOTypeModel ? "user" : "system",
-      content: this.defaultSystemMessage(contextTexts),
+      content: this.defaultSystemMessage(contextTexts, summary),
     };
 
     return [
@@ -347,12 +377,18 @@ export default abstract class BaseOpenAILikeProvider {
       .filter((r) => r.metadata.content !== undefined && r.metadata.content !== null && r.metadata.content !== '')
       .map((r) => String(r.metadata.content));
 
+    const shaped = await this.shapePrompt(
+      { history, contextTexts, summary: null },
+      { threadSlug: userPrompt.workspaceThreadSlug ?? history[0]?.workspaceThreadSlug ?? null, onStatus },
+    );
+
     return {
       citations: this.buildDocumentCitations(vectorSearchResults),
       formattedMessages: this.constructMessages({
-        chatHistory: history,
+        chatHistory: shaped.history,
         userPrompt: userPrompt.prompt as string,
-        contextTexts,
+        contextTexts: shaped.contextTexts,
+        summary: shaped.summary,
       }),
     }
   }

--- a/src/utils/AiProviders/onDevice/index.ts
+++ b/src/utils/AiProviders/onDevice/index.ts
@@ -1,6 +1,7 @@
 import { defaultModels } from "@/utils/models";
 import LlamaRnWrapper, { ILlamaRnStreamCallback, OnDeviceRuntimeInfo } from "./llamaRn";
-import BaseOpenAILikeProvider, { IAvailableModel, ICompleteResponse, IStreamCallback, IStreamEvent } from "../baseOpenAILikeProvider";
+import BaseOpenAILikeProvider, { IAvailableModel, ICompleteResponse, IStreamCallback, IStreamEvent, PromptShape } from "../baseOpenAILikeProvider";
+import ContextCompactor from "@/utils/chat/contextCompaction";
 import OpenAILite from "@/utils/openai";
 import MODEL_CARDS, { EMBEDDING_MODEL } from "@/utils/models/defaults";
 import { DEFAULT_GGUF_FOLDER } from "@/utils/models/manager";
@@ -248,6 +249,54 @@ export default class OnDeviceProvider extends BaseOpenAILikeProvider {
     return this.submodule!.getChatCompletion(messages);
   }
 
+  /**
+   * Fits the prompt to the on-device context window before it is rendered:
+   *  - RAG chunks are capped to their share of the prompt budget (they sit in the system prompt, which pruning never touches)
+   *  - the oldest chats are replaced by the thread's rolling summary (see `ContextCompactor`)
+   * Compaction normally runs in the background after each reply (`scheduleCompaction`), so this
+   * only summarises inline when history outgrew the budget since then - the user sees a status line for it.
+   */
+  protected override async shapePrompt(shape: PromptShape, { threadSlug, onStatus }: { threadSlug: string | null; onStatus?: (status: string) => void }): Promise<PromptShape> {
+    if (!this.submodule) return shape;
+    const contextTexts = await this.submodule.fitContextTexts(shape.contextTexts);
+    if (!threadSlug || !shape.history.length) return { ...shape, contextTexts };
+
+    const compactor = this.submodule.compactor;
+    let resolved = ContextCompactor.resolve(shape.history, await ContextCompactor.load(threadSlug));
+    if (resolved.stale) await ContextCompactor.clear(threadSlug);
+
+    if (compactor.isRunning) {
+      this.log('A background compaction is still running - waiting for it before building the prompt');
+      onStatus?.('Summarizing earlier conversation');
+      resolved = await compactor.compact({ threadSlug, history: shape.history, trigger: 'inline before prompt, after waiting on background pass' });
+    } else if (await compactor.shouldCompact(resolved.recent)) {
+      this.log('History outgrew the prompt budget since the last background pass (or that pass was skipped/failed) - compacting before this prompt');
+      onStatus?.('Summarizing earlier conversation');
+      resolved = await compactor.compact({ threadSlug, history: shape.history, trigger: 'inline before prompt' });
+    }
+    if (resolved.summary) {
+      this.log(`Sending a summary in place of the ${resolved.coveredCount} oldest chat(s); ${resolved.recent.length} sent verbatim`);
+      onStatus?.(`Using a summary of ${resolved.coveredCount} earlier message${resolved.coveredCount === 1 ? '' : 's'}`);
+    }
+    return { history: resolved.recent, contextTexts, summary: resolved.summary };
+  }
+
+  /**
+   * Folds old chats into the thread summary once history is over the trigger, so the next prompt
+   * is already compacted when the user sends it. Fire-and-forget: the compactor never throws and
+   * llama.rn rounds are queued, so a prompt sent meanwhile simply waits its turn.
+   */
+  private scheduleCompaction(messages: DynamicChatMessage[], textResponse: string) {
+    if (!this.submodule) return;
+    const last = messages[messages.length - 1];
+    const threadSlug = last?.workspaceThreadSlug;
+    if (!threadSlug || !last.uuid) return;
+    const history = [...messages.slice(0, -1), { ...last, response: { ...(last.response as any), textResponse } }];
+    this.submodule.compactor
+      .compact({ threadSlug, history, trigger: 'background after reply' })
+      .catch((error) => this.log('Background context compaction failed', error));
+  }
+
   override async chat({
     messages,
     streaming = false,
@@ -284,7 +333,7 @@ export default class OnDeviceProvider extends BaseOpenAILikeProvider {
     throwIfAborted(this.abortSignal);
 
     // Recursive tool call loop
-    await ToolsManager.toolCallLoop({
+    const finalResult = await ToolsManager.toolCallLoop({
       currentResponse: fullResult,
       runStreamCompletion: async (messages: any[], callback: IOnDeviceStreamCallback | IStreamCallback, availableTools: any[]) => {
         const result = await this.runSubmoduleStream(messages, callback as any, availableTools);
@@ -294,11 +343,14 @@ export default class OnDeviceProvider extends BaseOpenAILikeProvider {
       streamEmitter: (event: IStreamEvent, data: any) => onStream(event, data),
       currentMessageHistory: formattedMessages,
       signal: this.abortSignal,
+      maxToolResultChars: this.submodule.maxToolResultChars,
     });
 
     throwIfAborted(this.abortSignal);
+    if (finalResult.truncatedByContext) onStream('report_status', 'Reply was cut short - the context window is full');
     if (!!fullResult.metrics) onStream('report_metrics', fullResult.metrics);
     if (!!citations) onStream('report_citations', citations);
     onStream('complete', '');
+    this.scheduleCompaction(messages, finalResult.textResponse);
   }
 }

--- a/src/utils/AiProviders/onDevice/llamaRn/index.ts
+++ b/src/utils/AiProviders/onDevice/llamaRn/index.ts
@@ -12,6 +12,7 @@ import { stops } from '@/utils/chat';
 import { ICompleteResponse } from '@/utils/AiProviders/baseOpenAILikeProvider';
 import type OnDeviceProvider from '@/utils/AiProviders/onDevice/index';
 import { getDefaultContextLength } from '@/utils/contextLength';
+import ContextCompactor, { type CompactionChatMessage, truncateMiddle } from '@/utils/chat/contextCompaction';
 import { throwIfAborted } from '@/utils/chat/abort';
 
 export type NativeLlamaChatMessage = {
@@ -42,8 +43,11 @@ export type OnDeviceRuntimeInfo = {
 export default class LlamaRnWrapper {
   /**
    * Defaults are shared with `Workspace` so inference behaves the same when a workspace has no override.
-   * On overflow, the oldest chat turns are dropped before the prompt is sent (see `fitMessagesToContext`)
-   * and llama.cpp context shifting is enabled as a last line of defence during generation.
+   * Keeping inside the window, in order:
+   *  1. `OnDeviceProvider.shapePrompt` swaps the oldest chats for a rolling summary (`compactor`) and caps RAG chunks.
+   *  2. `fitMessagesToContext` drops the oldest remaining turns, then shrinks the latest message if it alone overflows.
+   *  3. `runCompletion` sizes `n_predict` to the room actually left so the reply ends cleanly instead of shifting.
+   *  4. llama.cpp context shifting stays on as a last line of defence.
    */
   /** Scales with device RAM up to a max of 2048 - see src/utils/contextLength.ts */
   static get DEFAULT_CONTEXT_LENGTH(): number {
@@ -65,10 +69,26 @@ export default class LlamaRnWrapper {
    */
   static RESPONSE_RESERVE_RATIO = 0.35;
 
+  /** Tokens left unused between prompt and reply for template/BOS slack when sizing `n_predict`. */
+  static CONTEXT_SAFETY_MARGIN = 16;
+  /** Smallest reply we ask for once the prompt has crowded the window. Below this, context shifting takes over. */
+  static MIN_N_PREDICT = 64;
+  /** A message is never truncated below this many characters by `fitMessagesToContext`. */
+  static MIN_TRUNCATED_MESSAGE_CHARS = 200;
+  /** Share of the prompt budget RAG chunks may occupy - they live in the system prompt which pruning cannot touch. */
+  static CONTEXT_TEXTS_BUDGET_RATIO = 0.35;
+  /** Share of the prompt budget a single tool result may occupy. */
+  static TOOL_RESULT_BUDGET_RATIO = 0.25;
+  /** Rough English chars-per-token used to turn token budgets into character caps. */
+  static CHARS_PER_TOKEN = 3.5;
+
   private parent: OnDeviceProvider;
   private model: string;
   private ggufFilePath: string | null = null;
   private context: LlamaContext | null = null;
+  /** Serialises everything that touches `context.completion` - llama.rn owns one context and cannot run two completions at once. */
+  private completionQueue: Promise<unknown> = Promise.resolve();
+  private _compactor: { contextLength: number; instance: ContextCompactor } | null = null;
   private initializing: Promise<boolean> | null = null;
   private keepAliveTimer: ReturnType<typeof setTimeout> | null = null;
   private keepAliveInterval = 1000 * 60 * 5;
@@ -102,6 +122,46 @@ export default class LlamaRnWrapper {
 
   get contextLength() {
     return this.parent.workspace?.contextLength ?? LlamaRnWrapper.DEFAULT_CONTEXT_LENGTH;
+  }
+
+  /** Tokens kept free for the reply when fitting the prompt. */
+  get responseReserve(): number {
+    return Math.min(this.nPredict, Math.max(128, Math.floor(this.contextLength * LlamaRnWrapper.RESPONSE_RESERVE_RATIO)));
+  }
+
+  /** Tokens the rendered prompt (system + summary + RAG + history + user message) may occupy. */
+  get promptBudget(): number {
+    return Math.max(64, this.contextLength - this.responseReserve);
+  }
+
+  /** Character cap applied to each tool result before it is fed back to the model. */
+  get maxToolResultChars(): number {
+    return Math.floor(this.promptBudget * LlamaRnWrapper.TOOL_RESULT_BUDGET_RATIO * LlamaRnWrapper.CHARS_PER_TOKEN);
+  }
+
+  /** Token budget shared by all RAG chunks in one prompt. */
+  get contextTextsTokenBudget(): number {
+    return Math.floor(this.promptBudget * LlamaRnWrapper.CONTEXT_TEXTS_BUDGET_RATIO);
+  }
+
+  /**
+   * Rolling-summary compactor bound to this model's window and tokenizer. Rebuilt when the
+   * workspace context length changes so its budgets stay in step.
+   */
+  get compactor(): ContextCompactor {
+    if (!this._compactor || this._compactor.contextLength !== this.contextLength) {
+      this._compactor = {
+        contextLength: this.contextLength,
+        instance: new ContextCompactor({
+          contextWindow: this.contextLength,
+          promptBudget: this.promptBudget,
+          countTokens: (messages) => this.countTokens(messages),
+          complete: (messages, { maxTokens }) => this.completeUtility(messages, maxTokens),
+          log: (message, ...args) => this.log(message, ...args),
+        }),
+      };
+    }
+    return this._compactor.instance;
   }
 
   get isLoaded() {
@@ -254,6 +314,54 @@ export default class LlamaRnWrapper {
     return tokens.length;
   }
 
+  /** Tokens `messages` render to through the model's chat template. Loads the model if needed. */
+  async countTokens(messages: CompactionChatMessage[]): Promise<number> {
+    if (!this.context) await this.initialize();
+    return this.countPromptTokens(messages as any);
+  }
+
+  private async countText(text: string): Promise<number> {
+    if (!this.context) await this.initialize();
+    if (!this.context) throw new Error('LlamaRnWrapper::countText: Model not initialized');
+    const { tokens } = await this.context.tokenize(text);
+    return tokens.length;
+  }
+
+  /**
+   * Keeps RAG chunks inside their share of the prompt budget. Whole chunks are kept in
+   * relevance order; the first one that does not fit is cut to the remaining room and the rest dropped.
+   */
+  async fitContextTexts(contextTexts: string[]): Promise<string[]> {
+    if (!contextTexts.length) return contextTexts;
+    const budget = this.contextTextsTokenBudget;
+    const kept: string[] = [];
+    let used = 0;
+    for (const text of contextTexts) {
+      const tokens = await this.countText(text);
+      if (used + tokens <= budget) {
+        kept.push(text);
+        used += tokens;
+        continue;
+      }
+      const remaining = budget - used;
+      if (remaining >= 48) kept.push(`${text.slice(0, Math.floor(remaining * LlamaRnWrapper.CHARS_PER_TOKEN))}...`);
+      break;
+    }
+    if (kept.length !== contextTexts.length || kept.some((text, i) => text !== contextTexts[i])) {
+      this.log(`Fitted ${contextTexts.length} context chunk(s) into a ${budget} token budget - kept ${kept.length}`);
+    }
+    return kept;
+  }
+
+  /**
+   * One-off, tool-free completion for housekeeping (eg: context summaries). Queued behind
+   * any running generation and never aborted by the user's stop button.
+   */
+  async completeUtility(messages: CompactionChatMessage[], maxTokens: number): Promise<string> {
+    const result = await this.runCompletion(messages as any, [], undefined, null, { nPredict: maxTokens });
+    return result.content ?? result.text ?? '';
+  }
+
   /**
    * Drops the oldest chat turns until the rendered prompt leaves room for a response.
    * The system prompt (index 0) and the latest user message are always kept.
@@ -261,8 +369,7 @@ export default class LlamaRnWrapper {
    */
   async fitMessagesToContext(messages: NativeLlamaChatMessage[], tools?: any[]): Promise<{ messages: NativeLlamaChatMessage[]; promptTokens: number; dropped: number }> {
     const nCtx = this.contextLength;
-    const reserve = Math.min(this.nPredict, Math.max(128, Math.floor(nCtx * LlamaRnWrapper.RESPONSE_RESERVE_RATIO)));
-    const budget = Math.max(64, nCtx - reserve);
+    const budget = this.promptBudget;
 
     let working = [...messages];
     let dropped = 0;
@@ -279,16 +386,36 @@ export default class LlamaRnWrapper {
     }
 
     if (dropped) this.log(`Dropped ${dropped} oldest message(s) to fit ${nCtx} token context (prompt now ${promptTokens} tokens, budget ${budget})`);
-    if (promptTokens > budget) this.log(`Prompt is ${promptTokens} tokens which exceeds the ${budget} token budget even after trimming - relying on context shifting.`);
+    // Nothing left to drop but still over budget: the latest message itself (a long prompt, or a
+    // user message with tool results merged in) is the culprit. Shrink it rather than let
+    // llama.cpp's context shift evict the system prompt mid-generation.
+    if (promptTokens > budget) {
+      const lastIndex = working.length - 1;
+      const original = working[lastIndex];
+      const content = typeof original?.content === 'string' ? original.content : null;
+      if (content && content.length > LlamaRnWrapper.MIN_TRUNCATED_MESSAGE_CHARS) {
+        let maxChars = Math.floor(content.length * 0.75);
+        while (promptTokens > budget && maxChars >= LlamaRnWrapper.MIN_TRUNCATED_MESSAGE_CHARS) {
+          working[lastIndex] = { ...original, content: truncateMiddle(content, maxChars) } as NativeLlamaChatMessage;
+          promptTokens = await this.countPromptTokens(working, tools);
+          maxChars = Math.floor(maxChars * 0.75);
+        }
+        this.log(`Truncated the latest message from ${content.length} to ${String(working[lastIndex].content).length} chars to fit the ${budget} token budget (prompt now ${promptTokens} tokens)`);
+      }
+      if (promptTokens > budget) this.log(`Prompt is ${promptTokens} tokens which exceeds the ${budget} token budget even after trimming - relying on context shifting.`);
+    }
     return { messages: working, promptTokens, dropped };
   }
 
-  private toCompleteResponse(result: NativeCompletionResult): ICompleteResponse {
-    if (result.context_full) this.log('Context window filled during generation - the response may have been cut short. Consider raising the workspace context length.');
+  private toCompleteResponse(result: NativeCompletionResult & { cappedByContext?: boolean }): ICompleteResponse {
+    // Either llama.cpp filled the window, or we shrank n_predict to the remaining room and the model used all of it.
+    const truncatedByContext = !!result.context_full || (!!result.cappedByContext && !!result.stopped_limit && !result.stopped_eos && !result.stopped_word);
+    if (truncatedByContext) this.log('Reply hit the context window limit and was cut short. Consider raising the workspace context length.');
     if (result.truncated) this.log('Prompt was truncated by llama.cpp to fit the context window.');
     return {
       // `content` has reasoning/tool call markup already parsed out by chat.cpp; `text` is the raw output.
       textResponse: result.content ?? result.text ?? '',
+      truncatedByContext,
       toolCalls: result.tool_calls?.length ? result.tool_calls : undefined,
       metrics: {
         prompt_tokens: result.timings.prompt_n,
@@ -300,13 +427,35 @@ export default class LlamaRnWrapper {
     };
   }
 
-  private async runCompletion(
+  private runExclusive<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.completionQueue.catch(() => null).then(task);
+    this.completionQueue = run.catch(() => null);
+    return run;
+  }
+
+  /**
+   * One llama.rn round. Rounds are queued so a background context summary and the user's
+   * next prompt never hit the single native context at the same time.
+   */
+  private runCompletion(
     messages: NativeLlamaChatMessage[],
     availableTools: any[] = [],
     onToken?: (data: TokenData) => void,
     signal?: AbortSignal | null,
-  ): Promise<NativeCompletionResult> {
+    options: { nPredict?: number } = {},
+  ): Promise<NativeCompletionResult & { cappedByContext: boolean }> {
+    return this.runExclusive(() => this.runCompletionUnlocked(messages, availableTools, onToken, signal, options));
+  }
+
+  private async runCompletionUnlocked(
+    messages: NativeLlamaChatMessage[],
+    availableTools: any[],
+    onToken: ((data: TokenData) => void) | undefined,
+    signal: AbortSignal | null | undefined,
+    options: { nPredict?: number },
+  ): Promise<NativeCompletionResult & { cappedByContext: boolean }> {
     this.keepAlive();
+    throwIfAborted(signal); // may have been stopped while queued behind another round
     if (!this.context) await this.initialize();
     if (!this.context) throw new Error('LlamaRnWrapper::runCompletion: Model not initialized');
 
@@ -314,7 +463,15 @@ export default class LlamaRnWrapper {
     if (availableTools.length && !useTools) this.log(`Model template has no tool support - ${availableTools.length} tool(s) will not be offered.`);
 
     const tools = useTools ? availableTools : undefined;
-    const { messages: fitted } = await this.fitMessagesToContext(messages, tools);
+    const { messages: fitted, promptTokens } = await this.fitMessagesToContext(messages, tools);
+
+    // Ask for no more tokens than the window has left so the reply ends cleanly (stopped_limit)
+    // instead of llama.cpp shifting the KV cache and evicting the start of the prompt.
+    const requestedPredict = options.nPredict ?? this.nPredict;
+    const room = this.contextLength - promptTokens - LlamaRnWrapper.CONTEXT_SAFETY_MARGIN;
+    const nPredict = Math.max(LlamaRnWrapper.MIN_N_PREDICT, Math.min(requestedPredict, room));
+    const cappedByContext = nPredict < requestedPredict;
+    if (cappedByContext) this.log(`Reply capped at ${nPredict} tokens - prompt uses ${promptTokens} of the ${this.contextLength} token window`);
 
     // The user may have stopped while the model was loading or the prompt was being fitted -
     // never start generating in that case. Once generating, an abort interrupts the native loop.
@@ -324,10 +481,10 @@ export default class LlamaRnWrapper {
 
     this.isGenerating = true;
     try {
-      return await this.context.completion(
+      const result = await this.context.completion(
         {
           messages: fitted as any,
-          n_predict: this.nPredict,
+          n_predict: nPredict,
           stop: [...stops],
           jinja: this.context.isJinjaSupported(),
           // Keep <think> blocks inline - the chat UI already extracts them into the thought chain.
@@ -337,6 +494,7 @@ export default class LlamaRnWrapper {
         },
         onToken,
       );
+      return { ...result, cappedByContext };
     } finally {
       this.isGenerating = false;
       signal?.removeEventListener('abort', onAbort);

--- a/src/utils/ToolsManager/index.ts
+++ b/src/utils/ToolsManager/index.ts
@@ -6,6 +6,7 @@ import Tools from './tools';
 import { safeJsonParse } from "../formatters";
 import Telemetry from "../Telemetry";
 import { throwIfAborted } from "../chat/abort";
+import { truncateMiddle } from "../chat/contextCompaction";
 
 type ToolManagerTool = {
     /** Definition of the tool - this can be used to generate a tool call */
@@ -40,6 +41,12 @@ type ToolCallLoopProps = {
     runStreamCompletion: (messages: any[], callback: IStreamCallback, availableTools: any[]) => Promise<ICompleteResponse>;
     streamEmitter: (event: IStreamEvent, data: any) => void;
     currentMessageHistory: any[];
+    /**
+     * Max characters of a tool result that are fed back to the model (the UI still gets the full
+     * result). Providers with small context windows set this so one big result cannot evict the
+     * system prompt. Unset = unlimited.
+     */
+    maxToolResultChars?: number;
     /** Whether to merge the tool call results into the previous message (this is the default behavior) */
     mergeToolCallResults?: boolean;
     /** Session abort signal - when it fires the loop stops before the next tool execution / LLM round */
@@ -128,6 +135,7 @@ class ToolsManager {
         toolCalls: NativeCompletionResult['tool_calls'],
         streamEmitter: (event: IStreamEvent, data: any) => void,
         currentMessageHistory: any[],
+        maxToolResultChars?: number,
     ): Promise<any[]> {
         const nextMessages = [...currentMessageHistory];
 
@@ -160,9 +168,11 @@ class ToolsManager {
                 signature: humanReadableToolCall.signature,
                 result: toolCallResult ?? 'Error: No result from tool call',
             });
+            const modelVisibleResult = maxToolResultChars ? truncateMiddle(String(toolCallResult ?? ''), maxToolResultChars) : toolCallResult;
+            if (modelVisibleResult !== toolCallResult) this.log(`ToolsManager::manageToolCallExecutions: Truncated ${toolCallName} result from ${String(toolCallResult).length} to ${maxToolResultChars} chars for the model`);
             nextMessages.push({
                 role: 'tool',
-                content: toolCallResult,
+                content: modelVisibleResult,
                 signature: humanReadableToolCall.signature,
                 function: toolCall.function.name,
             });
@@ -190,6 +200,7 @@ class ToolsManager {
         currentMessageHistory,
         mergeToolCallResults = true,
         signal = null,
+        maxToolResultChars,
     }: ToolCallLoopProps): Promise<ICompleteResponse> {
         let willLoop = currentResponse.toolCalls && currentResponse.toolCalls.length > 0;
         if (!willLoop) return currentResponse;
@@ -201,7 +212,7 @@ class ToolsManager {
         do {
             // The user stopped the chat mid-round - do not execute tools or ask the LLM again.
             throwIfAborted(signal);
-            nextMessages = await this.manageToolCallExecutions(nextResponse.toolCalls ?? [], streamEmitter, nextMessages);
+            nextMessages = await this.manageToolCallExecutions(nextResponse.toolCalls ?? [], streamEmitter, nextMessages, maxToolResultChars);
             throwIfAborted(signal);
             for (const [index, message] of nextMessages.entries()) {
                 if (message.role === 'tool' && mergeToolCallResults) {

--- a/src/utils/chat/contextCompaction.ts
+++ b/src/utils/chat/contextCompaction.ts
@@ -1,0 +1,288 @@
+import { type DynamicChatMessage } from '@/screens/WorkspaceChat/ChatHistory';
+import WorkspaceThread, { type ThreadContextSummary } from '@/database/models/WorkspaceThread';
+import { parseThinkingParts } from '@/utils/chat';
+
+/** Plain OpenAI-style chat message - the only shape the compactor needs from a provider. */
+export type CompactionChatMessage = { role: 'system' | 'user' | 'assistant'; content: string };
+
+export type ContextCompactorConfig = {
+  /** Total tokens the model can see (prompt + reply). */
+  contextWindow: number;
+  /** Tokens the prompt may occupy, ie: `contextWindow` minus the room reserved for the reply. */
+  promptBudget: number;
+  /** Counts the tokens `messages` render to for the target model (ideally through its real chat template). */
+  countTokens: (messages: CompactionChatMessage[]) => Promise<number>;
+  /** Runs a short, tool-free completion and returns its text. */
+  complete: (messages: CompactionChatMessage[], options: { maxTokens: number }) => Promise<string>;
+  log?: (message: string, ...args: any[]) => void;
+};
+
+/**
+ * The saved chat history split into the part represented by a summary and the part
+ * that is still sent verbatim.
+ */
+export type ResolvedHistory = {
+  /** Summary of the oldest chats, or null when everything is sent verbatim. */
+  summary: string | null;
+  /** How many chats (from the start of the thread) `summary` stands in for. */
+  coveredCount: number;
+  /** Chats to send verbatim, in order. */
+  recent: DynamicChatMessage[];
+  /** True when a stored summary no longer matched the saved chats and was discarded. */
+  stale: boolean;
+};
+
+/**
+ * Drops the middle of `text` so it is at most `maxChars` long, keeping the head and tail.
+ * Used for tool results and single oversized messages that would otherwise blow the window.
+ */
+export function truncateMiddle(text: string, maxChars: number, headRatio: number = 0.7): string {
+  if (!text || maxChars <= 0 || text.length <= maxChars) return text;
+  const marker = '\n[...truncated to fit the context window...]\n';
+  const room = Math.max(0, maxChars - marker.length);
+  if (room < 32) return text.slice(0, maxChars);
+  const head = Math.floor(room * headRatio);
+  const tail = room - head;
+  return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`;
+}
+
+/**
+ * Keeps a long thread inside a small context window by folding its oldest chats into a
+ * rolling summary that is persisted on the thread (`WorkspaceThread.contextSummary`).
+ *
+ * Provider agnostic: the caller supplies the window size, a token counter and a
+ * completion function, so any provider that knows its context window can use this.
+ * Only the on-device provider does today.
+ *
+ * Flow per turn:
+ *  1. `resolve()` checks the stored summary still lines up with the saved chats
+ *     (deleting/retrying an earlier chat invalidates it) and returns summary + recent chats.
+ *  2. The provider sends `summary` inside the system prompt and `recent` verbatim.
+ *  3. After the reply, `compact()` runs in the background: once the verbatim history is
+ *     using more than `HISTORY_TRIGGER_RATIO` of the prompt budget, the oldest chats are
+ *     summarised (incrementally, on top of the previous summary) until the remainder is
+ *     under `HISTORY_TARGET_RATIO`. The next prompt is already compacted when the user sends it.
+ *
+ * `compact()` is also safe to call inline before a prompt when history already overflows -
+ * calls are serialised so a background run and an inline run never overlap.
+ */
+export default class ContextCompactor {
+  /** Verbatim history may use this share of the prompt budget before compaction kicks in. */
+  static HISTORY_TRIGGER_RATIO = 0.5;
+  /** Compaction folds chats until the verbatim history is under this share of the prompt budget. */
+  static HISTORY_TARGET_RATIO = 0.3;
+  /** The newest chats are never summarised so the model always sees the immediate exchange verbatim. */
+  static MIN_CHATS_KEPT_VERBATIM = 1;
+  /** Bounds for the summary length (tokens) - it scales with the window (1/8th) between these. */
+  static SUMMARY_MIN_TOKENS = 64;
+  static SUMMARY_MAX_TOKENS = 256;
+
+  private config: ContextCompactorConfig;
+  /** In-flight compaction, if any. Later calls wait on it instead of running concurrently. */
+  private pending: Promise<unknown> | null = null;
+
+  constructor(config: ContextCompactorConfig) {
+    this.config = config;
+  }
+
+  private log(message: string, ...args: any[]) {
+    this.config.log?.(`[ContextCompactor] ${message}`, ...args);
+  }
+
+  get isRunning(): boolean {
+    return this.pending !== null;
+  }
+
+  /** Max tokens the summary itself may take. */
+  get summaryMaxTokens(): number {
+    const scaled = Math.floor(this.config.contextWindow / 8);
+    return Math.min(ContextCompactor.SUMMARY_MAX_TOKENS, Math.max(ContextCompactor.SUMMARY_MIN_TOKENS, scaled));
+  }
+
+  get triggerTokens(): number {
+    return Math.floor(this.config.promptBudget * ContextCompactor.HISTORY_TRIGGER_RATIO);
+  }
+
+  get targetTokens(): number {
+    return Math.floor(this.config.promptBudget * ContextCompactor.HISTORY_TARGET_RATIO);
+  }
+
+  static load(threadSlug: string): Promise<ThreadContextSummary | null> {
+    return WorkspaceThread.getContextSummary(threadSlug);
+  }
+
+  static clear(threadSlug: string): Promise<boolean> {
+    return WorkspaceThread.setContextSummary(threadSlug, null);
+  }
+
+  /**
+   * Splits `history` into the chats a stored summary stands in for and the chats to send
+   * verbatim. A summary only applies when the chat it ends on is still at the position it
+   * was when the summary was written - anything else means history changed underneath it.
+   */
+  static resolve(history: DynamicChatMessage[], stored: ThreadContextSummary | null): ResolvedHistory {
+    if (!stored?.summary || !stored.throughUuid || !stored.coveredCount) {
+      return { summary: null, coveredCount: 0, recent: history, stale: false };
+    }
+    const index = history.findIndex((chat) => chat.uuid === stored.throughUuid);
+    if (index === -1 || index !== stored.coveredCount - 1) {
+      return { summary: null, coveredCount: 0, recent: history, stale: true };
+    }
+    return {
+      summary: stored.summary,
+      coveredCount: stored.coveredCount,
+      recent: history.slice(stored.coveredCount),
+      stale: false,
+    };
+  }
+
+  /** Saved chats as user/assistant pairs (what the provider ultimately sends). */
+  static toMessages(history: DynamicChatMessage[]): CompactionChatMessage[] {
+    return history.flatMap((chat) => [
+      { role: 'user' as const, content: String(chat.prompt ?? '') },
+      { role: 'assistant' as const, content: String(chat.response?.textResponse ?? '') },
+    ]);
+  }
+
+  /** Tokens the verbatim history alone would add to the prompt. */
+  async historyTokens(history: DynamicChatMessage[]): Promise<number> {
+    if (!history.length) return 0;
+    return this.config.countTokens(ContextCompactor.toMessages(history));
+  }
+
+  /** Whether the verbatim history has grown past the trigger share of the prompt budget. */
+  async shouldCompact(recent: DynamicChatMessage[]): Promise<boolean> {
+    if (recent.length <= ContextCompactor.MIN_CHATS_KEPT_VERBATIM) return false;
+    return (await this.historyTokens(recent)) > this.triggerTokens;
+  }
+
+  /**
+   * Loads the stored summary, validates it against `history` and, when the verbatim
+   * remainder is over the trigger (or `force` is set), folds the oldest chats into the
+   * summary and persists it. Never throws - on failure the unchanged resolution is returned
+   * so the caller can fall back to plain pruning.
+   */
+  compact({ threadSlug, history, force = false, trigger = 'unspecified' }: { threadSlug: string; history: DynamicChatMessage[]; force?: boolean; trigger?: string }): Promise<ResolvedHistory> {
+    const run = (this.pending ?? Promise.resolve())
+      .catch(() => null)
+      .then(() => this.compactNow({ threadSlug, history, force, trigger }));
+    this.pending = run;
+    run.finally(() => { if (this.pending === run) this.pending = null; }).catch(() => null);
+    return run;
+  }
+
+  private async compactNow({ threadSlug, history, force, trigger }: { threadSlug: string; history: DynamicChatMessage[]; force: boolean; trigger: string }): Promise<ResolvedHistory> {
+    const stored = await ContextCompactor.load(threadSlug);
+    let resolved = ContextCompactor.resolve(history, stored);
+    if (resolved.stale) {
+      this.log(`Stored summary for thread ${threadSlug} covered ${stored?.coveredCount} chat(s) ending at ${stored?.throughUuid}, but that chat is no longer at that position (deleted/retried/forked) - discarding it`);
+      await ContextCompactor.clear(threadSlug);
+    }
+
+    try {
+      const remaining = [...resolved.recent];
+      let remainingTokens = await this.historyTokens(remaining);
+      const startingTokens = remainingTokens;
+      const { contextWindow, promptBudget } = this.config;
+      const usage = `${resolved.recent.length} verbatim chat(s) = ${startingTokens} tokens, ${Math.round((startingTokens / promptBudget) * 100)}% of the ${promptBudget} token prompt budget (${contextWindow} token window, trigger ${this.triggerTokens})`;
+
+      if (!force && remainingTokens <= this.triggerTokens) {
+        this.log(`No compaction needed for thread ${threadSlug} [${trigger}]: ${usage}`);
+        return resolved;
+      }
+
+      const reason = force
+        ? `forced by caller`
+        : `verbatim history would take ${startingTokens} of the ${promptBudget} prompt tokens, leaving too little room before the ${contextWindow} token window overflows`;
+      this.log(`Compacting thread ${threadSlug} [${trigger}] because ${reason}. ${usage}`);
+
+      // Peel the oldest chats off until what is left fits the target share of the budget.
+      const toFold: DynamicChatMessage[] = [];
+      while (remaining.length > ContextCompactor.MIN_CHATS_KEPT_VERBATIM && remainingTokens > this.targetTokens) {
+        toFold.push(remaining.shift()!);
+        remainingTokens = await this.historyTokens(remaining);
+      }
+      if (!toFold.length) {
+        this.log(`Nothing to fold for thread ${threadSlug} - only ${remaining.length} chat(s) remain and the newest ${ContextCompactor.MIN_CHATS_KEPT_VERBATIM} is always kept verbatim`);
+        return resolved;
+      }
+
+      this.log(`Folding the ${toFold.length} oldest chat(s) into the summary for thread ${threadSlug}: history goes ${startingTokens} -> ${remainingTokens} tokens (target <= ${this.targetTokens}), ${remaining.length} chat(s) stay verbatim${resolved.summary ? `, extending an existing summary of ${resolved.coveredCount} chat(s)` : ''}`);
+      let summary = resolved.summary;
+      let coveredCount = resolved.coveredCount;
+      const queue = [...toFold];
+      while (queue.length) {
+        const batch = await this.takeBatchThatFits(summary, queue);
+        summary = await this.summarize(summary, batch);
+        coveredCount += batch.length;
+      }
+      if (!summary) throw new Error('Summarisation returned no text');
+
+      const last = toFold[toFold.length - 1];
+      if (!last.uuid) throw new Error('Cannot persist a summary for a chat without a uuid');
+      await WorkspaceThread.setContextSummary(threadSlug, { summary, throughUuid: last.uuid, coveredCount, updatedAt: Date.now() });
+      const summaryTokens = await this.config.countTokens([{ role: 'system', content: summary }]);
+      this.log(`Compaction done for thread ${threadSlug}: summary now covers ${coveredCount} chat(s) in ~${summaryTokens} tokens (cap ${this.summaryMaxTokens}); next prompt sends summary + ${remaining.length} verbatim chat(s) = ~${summaryTokens + remainingTokens} tokens instead of ${startingTokens}`);
+      resolved = { summary, coveredCount, recent: remaining, stale: false };
+      return resolved;
+    } catch (error) {
+      this.log('Compaction failed - history will be pruned instead', error);
+      return resolved;
+    }
+  }
+
+  /**
+   * Removes and returns the longest run of chats from the front of `queue` whose
+   * summarisation prompt fits the budget. A single chat too large on its own is
+   * truncated (middle removed) so progress is always made.
+   */
+  private async takeBatchThatFits(previousSummary: string | null, queue: DynamicChatMessage[]): Promise<DynamicChatMessage[]> {
+    const budget = Math.max(64, this.config.promptBudget - this.summaryMaxTokens);
+    const fits = async (chats: DynamicChatMessage[]) => (await this.config.countTokens(this.summaryPrompt(previousSummary, chats))) <= budget;
+
+    const batch: DynamicChatMessage[] = [];
+    while (queue.length && (await fits([...batch, queue[0]]))) batch.push(queue.shift()!);
+    if (batch.length) return batch;
+
+    // The oldest chat alone overflows the summariser - shrink its text until it fits.
+    let chat = { ...queue.shift()! };
+    let maxChars = Math.max(200, Math.floor((String(chat.prompt ?? '').length + String(chat.response?.textResponse ?? '').length) / 2));
+    for (let attempt = 0; attempt < 6; attempt++) {
+      chat = {
+        ...chat,
+        prompt: truncateMiddle(String(chat.prompt ?? ''), maxChars),
+        response: { ...(chat.response as any), textResponse: truncateMiddle(String(chat.response?.textResponse ?? ''), maxChars) },
+      };
+      if (await fits([chat])) break;
+      maxChars = Math.max(100, Math.floor(maxChars / 2));
+    }
+    return [chat];
+  }
+
+  private summaryPrompt(previousSummary: string | null, chats: DynamicChatMessage[]): CompactionChatMessage[] {
+    const maxWords = Math.max(40, Math.floor(this.summaryMaxTokens * 0.7));
+    const transcript = chats
+      .map((chat) => `User: ${String(chat.prompt ?? '').trim()}\nAssistant: ${String(chat.response?.textResponse ?? '').trim()}`)
+      .join('\n\n');
+    return [
+      {
+        role: 'system',
+        content: `You summarise conversations so they can be continued later. Write one plain-text summary of at most ${maxWords} words. Keep the user's goals, decisions made, important facts, names, numbers, and any open questions. Do not add commentary, headings, or a preamble - output only the summary.`,
+      },
+      {
+        role: 'user',
+        content: `${previousSummary ? `Summary so far:\n${previousSummary}\n\n` : ''}Conversation to add:\n${transcript}\n\nUpdated summary:`,
+      },
+    ];
+  }
+
+  private async summarize(previousSummary: string | null, chats: DynamicChatMessage[]): Promise<string> {
+    // Reasoning models may think before answering - give them room, then strip it.
+    const raw = await this.config.complete(this.summaryPrompt(previousSummary, chats), { maxTokens: this.summaryMaxTokens * 2 });
+    const { nonThinkingText } = parseThinkingParts(raw);
+    const text = (nonThinkingText || raw).replace(/^(updated )?summary:\s*/i, '').trim();
+    if (!text) throw new Error('Summarisation returned no text');
+    // Hard character guard in case the model ignored the word limit (~4 chars/token).
+    return truncateMiddle(text, this.summaryMaxTokens * 5, 0.85);
+  }
+}


### PR DESCRIPTION
## Context window guard for on-device models

On-device workspaces run with very small context windows (512-2048 tokens). Until now the only overflow handling was to drop the oldest turns before sending, and then rely on llama.cpp context shifting during generation. Context shifting evicts from the front of the KV cache, which is the system prompt and RAG context, so a long reply could silently lose the instructions it was following. Dropped turns were also lost with no trace.

### What this does

**Rolling summary (compaction)**
- When the verbatim history uses more than half the prompt budget, the oldest chats are summarised by the on-device model and stored on the thread (`WorkspaceThread.contextSummary`, schema v2 with migration).
- Runs in the background right after a reply completes, so the next prompt is already compacted when the user sends it. If history outgrew the budget anyway, it runs inline and the activity chain shows "Summarizing earlier conversation".
- Summaries are incremental (new chats are folded on top of the previous summary) and capped to 1/8th of the window, between 64 and 256 tokens.
- The summary records which chat it ends on. Deleting, retrying or forking earlier chats makes it stale and it is rebuilt automatically.
- The summary is rendered into the system prompt rather than as a fake turn, so it survives pruning and works with templates that require alternating roles.
- The activity chain shows "Using a summary of N earlier messages" whenever one is in play, so "the model forgot" is explainable.

**Budgets on the parts pruning can't touch**
- RAG chunks are capped to 35% of the prompt budget (whole chunks first, then a head-truncated partial).
- Tool results are capped to 25% of the prompt budget before being fed back to the model (UI still gets the full result). Opt-in via `maxToolResultChars` on the tool loop; only on-device sets it.

**Reply sizing and last resorts**
- `n_predict` is sized to the room actually left in the window so replies end cleanly with `stopped_limit` instead of triggering a shift. When that cuts a reply short the chain reports "Reply was cut short - the context window is full".
- If the last message alone still overflows (long prompt, merged tool results), its middle is trimmed. Context shifting stays on only as the final fallback.
- All llama.rn completions are queued so a background summary and the user's next prompt never run on the native context at the same time.

**Portability**
- `ContextCompactor` in `utils/chat/contextCompaction.ts` is provider agnostic: it takes a window size, a token counter and a completion function.
- `BaseOpenAILikeProvider` gains a protected `shapePrompt` hook (passthrough by default). Only the on-device provider implements it. Other providers can adopt it once their context window is known.

**Logging**
Every compaction decision logs why it did or did not run, tagged with its trigger (`background after reply`, `inline before prompt`), with the token usage vs. budget, what was folded, and the resulting summary size.

### Also in this PR
- Chat history: the assistant row sat flush against the next user message when a Sources chip or action buttons were the last element. The row now pads its bottom to match the markdown paragraph margin in that case.

### Testing
- `tsc --noEmit` and eslint introduce no new errors in touched files.
- Not yet run on a device. Please verify: the v1 -> v2 migration on an existing install, summary quality on a small-context workspace with a 1B-class model, and that the "Summarizing earlier conversation" status appears only when history outgrew the budget between turns.
