### PR TITLE
Add speech-to-text input via native OS speech recognition

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
     <!-- Needed only for devices running Android 9 (API 28) or lower -->
     <!-- Currently it is used only for storing chat sessions (/Download)-->

--- a/ios/AnythingLLM/Info.plist
+++ b/ios/AnythingLLM/Info.plist
@@ -37,6 +37,10 @@
 	<string>AnythingLLM uses the camera to scan connection QR codes and to take photos to send to your model.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>AnythingLLM needs access to your photos so you can attach an image to a prompt.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>AnythingLLM uses the microphone to transcribe your speech into a prompt.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>AnythingLLM uses speech recognition to convert your voice into text for chat prompts.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>MaterialIcons.ttf</string>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@react-native-firebase/analytics": "^23.3.1",
     "@react-native-firebase/app": "^23.3.1",
     "@react-native-masked-view/masked-view": "^0.3.1",
+    "@react-native-voice/voice": "^3.2.4",
     "@react-navigation/bottom-tabs": "^6.6.1",
     "@react-navigation/drawer": "^6.6.15",
     "@react-navigation/native": "^6.1.17",

--- a/patches/@react-native-voice+voice+3.2.4.patch
+++ b/patches/@react-native-voice+voice+3.2.4.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/@react-native-voice/voice/android/build.gradle b/node_modules/@react-native-voice/voice/android/build.gradle
+index 8fce879..3147125 100644
+--- a/node_modules/@react-native-voice/voice/android/build.gradle
++++ b/node_modules/@react-native-voice/voice/android/build.gradle
+@@ -62,6 +62,8 @@ def supportVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.
+ dependencies {
+     implementation fileTree(dir: 'libs', include: ['*.jar'])
+     testImplementation 'junit:junit:4.12'
+-    implementation "com.android.support:appcompat-v7:${supportVersion}"
++    // The source only imports androidx.annotation; the legacy support library
++    // pulled in support-compat and broke manifest merging against androidx.core.
++    implementation "androidx.annotation:annotation:1.7.1"
+     implementation 'com.facebook.react:react-native:+'
+ }
+diff --git a/node_modules/@react-native-voice/voice/android/src/main/java/com/wenkesj/voice/VoiceModule.java b/node_modules/@react-native-voice/voice/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+index f22833e..ba665b8 100644
+--- a/node_modules/@react-native-voice/voice/android/src/main/java/com/wenkesj/voice/VoiceModule.java
++++ b/node_modules/@react-native-voice/voice/android/src/main/java/com/wenkesj/voice/VoiceModule.java
+@@ -146,7 +146,10 @@ public class VoiceModule extends ReactContextBaseJavaModule implements Recogniti
+ 
+   @Override
+   public String getName() {
+-    return "RCTVoice";
++    // JS looks up NativeModules.Voice. The old bridge stripped the "RCT"
++    // prefix natively, but the New Architecture interop layer keys legacy
++    // modules by the exact getName() value, so "RCTVoice" resolves to null.
++    return "Voice";
+   }
+ 
+   @ReactMethod

--- a/src/components/VoiceRecordingIndicator/index.tsx
+++ b/src/components/VoiceRecordingIndicator/index.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View } from 'react-native';
+import Animated, {
+    useAnimatedStyle,
+    withTiming,
+    type SharedValue,
+} from 'react-native-reanimated';
+
+const BAR_WIDTH = 3;
+const BAR_GAP = 3;
+const MIN_HEIGHT = 6;
+const MAX_HEIGHT = 20;
+// Per-bar gain so the bars fan out unevenly instead of moving as one block.
+const BAR_GAINS = [0.7, 1.4, 1.0, 0.55];
+// How quickly a bar chases a new level. Volume samples arrive every ~50-100ms.
+const SETTLE_MS = 90;
+
+interface WaveBarProps {
+    volume: SharedValue<number>;
+    gain: number;
+}
+
+function WaveBar({ volume, gain }: WaveBarProps) {
+    const animatedStyle = useAnimatedStyle(() => {
+        const level = Math.min(1, volume.value * gain);
+        const target = MIN_HEIGHT + (MAX_HEIGHT - MIN_HEIGHT) * level;
+        return {
+            height: withTiming(target, { duration: SETTLE_MS }),
+            width: BAR_WIDTH,
+            borderRadius: BAR_WIDTH / 2,
+            backgroundColor: '#46C8FF',
+        };
+    });
+
+    return <Animated.View style={animatedStyle} />;
+}
+
+interface VoiceRecordingIndicatorProps {
+    /** Normalized mic level in [0, 1]; see `useSpeechToText().volume`. */
+    volume: SharedValue<number>;
+}
+
+/**
+ * Live waveform driven by microphone level. Bars sit at their minimum height
+ * while listening in silence and grow with input loudness, so the user can
+ * see the recognizer is actually hearing them.
+ */
+export default function VoiceRecordingIndicator({ volume }: VoiceRecordingIndicatorProps) {
+    return (
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: BAR_GAP, height: 25 }}>
+            {BAR_GAINS.map((gain, i) => (
+                <WaveBar key={i} volume={volume} gain={gain} />
+            ))}
+        </View>
+    );
+}

--- a/src/hooks/useSpeechToText.ts
+++ b/src/hooks/useSpeechToText.ts
@@ -1,0 +1,134 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Alert, PermissionsAndroid, Platform } from 'react-native';
+import { useSharedValue, type SharedValue } from 'react-native-reanimated';
+import Voice, {
+    SpeechResultsEvent,
+    SpeechErrorEvent,
+    SpeechEndEvent,
+    SpeechVolumeChangeEvent,
+} from '@react-native-voice/voice';
+
+export interface SpeechToTextInterface {
+    isListening: boolean;
+    /**
+     * Normalized input loudness in [0, 1], updated on the UI thread as the OS
+     * reports microphone levels. Read it from a reanimated worklet so the
+     * waveform can react without re-rendering React on every sample.
+     */
+    volume: SharedValue<number>;
+    startListening: () => Promise<void>;
+    stopListening: () => Promise<void>;
+    toggleListening: () => Promise<void>;
+}
+
+async function ensureMicPermission(): Promise<boolean> {
+    if (Platform.OS !== 'android') return true;
+    const granted = await PermissionsAndroid.request(
+        PermissionsAndroid.PERMISSIONS.RECORD_AUDIO,
+        {
+            title: 'Microphone access',
+            message: 'AnythingLLM needs microphone access to transcribe your speech into a prompt.',
+            buttonPositive: 'Allow',
+            buttonNegative: 'Cancel',
+        },
+    );
+    return granted === PermissionsAndroid.RESULTS.GRANTED;
+}
+
+/**
+ * Android reports RMS in dB, typically -2..10. iOS reports a value the lib
+ * already normalizes to 0..10. Collapse both into [0, 1].
+ */
+function normalizeVolume(raw: number): number {
+    const scaled = Platform.OS === 'android' ? (raw + 2) / 12 : raw / 10;
+    return Math.min(1, Math.max(0, scaled));
+}
+
+export default function useSpeechToText(
+    onTranscript: (text: string) => void,
+): SpeechToTextInterface {
+    const [isListening, setIsListening] = useState(false);
+    const volume = useSharedValue(0);
+    const onTranscriptRef = useRef(onTranscript);
+    onTranscriptRef.current = onTranscript;
+
+    useEffect(() => {
+        // Both events carry the cumulative best transcription for the session,
+        // so each one can replace the prompt wholesale. Android streams interim
+        // text via partial results and sends a final onSpeechResults; iOS sends
+        // onSpeechResults continuously and its partials are non-string objects.
+        function onSpeechResults(e: SpeechResultsEvent) {
+            const text = e.value?.[0];
+            if (typeof text === 'string' && text) onTranscriptRef.current(text);
+        }
+
+        function onSpeechEnd(_e: SpeechEndEvent) {
+            volume.value = 0;
+            setIsListening(false);
+        }
+
+        function onSpeechError(e: SpeechErrorEvent) {
+            volume.value = 0;
+            setIsListening(false);
+            const code = e.error?.code;
+            // "no-speech" / code 6 on Android means silence — not a real error
+            if (code === '6' || code === 'no-speech') return;
+            // "recognition busy" / code 8 means another recognizer is active
+            if (code === '8' || code === 'recognition-busy') return;
+            console.warn('[STT] error', e.error);
+        }
+
+        function onSpeechVolumeChanged(e: SpeechVolumeChangeEvent) {
+            if (typeof e.value === 'number') volume.value = normalizeVolume(e.value);
+        }
+
+        Voice.onSpeechResults = onSpeechResults;
+        Voice.onSpeechPartialResults = onSpeechResults;
+        Voice.onSpeechEnd = onSpeechEnd;
+        Voice.onSpeechError = onSpeechError;
+        Voice.onSpeechVolumeChanged = onSpeechVolumeChanged;
+
+        return () => {
+            Voice.destroy().then(Voice.removeAllListeners);
+        };
+    }, []);
+
+    const startListening = useCallback(async () => {
+        const hasPermission = await ensureMicPermission();
+        if (!hasPermission) {
+            Alert.alert(
+                'Microphone access required',
+                'Enable microphone access in your device settings to use speech-to-text.',
+            );
+            return;
+        }
+
+        try {
+            await Voice.start('en-US');
+            setIsListening(true);
+        } catch (err) {
+            console.warn('[STT] failed to start', err);
+            setIsListening(false);
+        }
+    }, []);
+
+    const stopListening = useCallback(async () => {
+        try {
+            await Voice.stop();
+        } catch {
+            // already stopped
+        }
+        volume.value = 0;
+        setIsListening(false);
+    }, []);
+
+    const toggleListening = useCallback(async () => {
+        if (isListening) {
+            await stopListening();
+        } else {
+            await startListening();
+        }
+    }, [isListening, startListening, stopListening]);
+
+    return { isListening, volume, startListening, stopListening, toggleListening };
+}

--- a/src/screens/WorkspaceChat/PromptInput/Actions/index.tsx
+++ b/src/screens/WorkspaceChat/PromptInput/Actions/index.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
 import { TouchableOpacity, View } from 'react-native';
-import { PaperPlaneRight, Stop } from "phosphor-react-native";
+import { Microphone, PaperPlaneRight, Stop } from "phosphor-react-native";
 import { AttachmentInterface } from '@/hooks/useAttachments';
 import AttachmentsButton from './AttachmentsButton';
 import { SettingsActionIcon } from './Settings';
 import { type ChatHandlerInterface } from '@/hooks/useChatHandler/index';
+import { type SpeechToTextInterface } from '@/hooks/useSpeechToText';
+import VoiceRecordingIndicator from '@/components/VoiceRecordingIndicator';
 
 export const ACTION_MENU_HEIGHT = 40;
-export default function ActionMenu({ isFullScreen, chatHandler, ...props }: { isFullScreen: boolean, sheetIndex?: number, attachmentHandler: AttachmentInterface, chatHandler: ChatHandlerInterface }) {
+export default function ActionMenu({ isFullScreen, chatHandler, speechToText, ...props }: {
+    isFullScreen: boolean,
+    sheetIndex?: number,
+    attachmentHandler: AttachmentInterface,
+    chatHandler: ChatHandlerInterface,
+    speechToText: SpeechToTextInterface,
+}) {
+    const promptIsEmpty = !chatHandler.prompt?.trim();
+
     return (
         <View
             style={{ height: ACTION_MENU_HEIGHT, zIndex: 2, paddingHorizontal: 15 }}
@@ -21,8 +31,6 @@ export default function ActionMenu({ isFullScreen, chatHandler, ...props }: { is
 
             <View className='flex flex-row items-center gap-x-4'>
                 {chatHandler.isWorking ? (
-                    // While a reply is generating the send button becomes a stop button. Stopping
-                    // aborts the model (local, external or remote) and discards the unfinished chat.
                     <TouchableOpacity
                         onPress={chatHandler.abortChat}
                         accessibilityLabel='Stop generating'
@@ -30,10 +38,26 @@ export default function ActionMenu({ isFullScreen, chatHandler, ...props }: { is
                     >
                         <Stop size={25} color="#FFF" weight='fill' />
                     </TouchableOpacity>
+                ) : speechToText.isListening ? (
+                    <TouchableOpacity
+                        onPress={speechToText.stopListening}
+                        accessibilityLabel='Stop recording'
+                        className='flex flex-row items-center gap-x-2'
+                    >
+                        <VoiceRecordingIndicator volume={speechToText.volume} />
+                    </TouchableOpacity>
+                ) : promptIsEmpty ? (
+                    <TouchableOpacity
+                        onPress={speechToText.startListening}
+                        disabled={chatHandler.promptDisabled}
+                        accessibilityLabel='Voice input'
+                        className='flex flex-row items-center gap-x-2 disabled:opacity-50'
+                    >
+                        <Microphone size={25} color="#FFF" weight='fill' />
+                    </TouchableOpacity>
                 ) : (
                     <TouchableOpacity
                         onLongPress={chatHandler.reset}
-                        // Images ride along with the prompt; documents were already embedded when attached.
                         onPress={() => chatHandler.submitPrompt(undefined, props.attachmentHandler.imageAttachments)}
                         disabled={chatHandler.promptDisabled}
                         accessibilityLabel='Send prompt'

--- a/src/screens/WorkspaceChat/PromptInput/index.tsx
+++ b/src/screens/WorkspaceChat/PromptInput/index.tsx
@@ -31,6 +31,7 @@ import { PATHS } from "@/utils/paths";
 import useRouteObserver from "@/hooks/useRouteObserver";
 import { useChatHandlerContext } from "@/hooks/useChatHandler/index";
 import useLlmPreference from "@/hooks/useLLMPreference";
+import useSpeechToText from "@/hooks/useSpeechToText";
 
 const defaultPadding = [0, 0, 32]; // top padding for snap points
 export const snapPointsDefault = ["22%", "60%", "100%"];
@@ -55,6 +56,10 @@ export default function PromptInput({ attachmentHandler }: PromptInputProps) {
   const [sheetIndex, setSheetIndex] = useState(0);
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [isFullScreen, setIsFullScreen] = useState(false);
+
+  const speechToText = useSpeechToText(
+    useCallback((text: string) => chatHandler.setPrompt(text), [chatHandler]),
+  );
 
   const hasModelSelected = useMemo(() => {
     return !!llmPreferences?.config?.model;
@@ -255,6 +260,7 @@ export default function PromptInput({ attachmentHandler }: PromptInputProps) {
             sheetIndex={sheetIndex}
             attachmentHandler={attachmentHandler}
             chatHandler={chatHandler}
+            speechToText={speechToText}
           />
         </Animated.View>
       </BottomSheetModal>

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,13 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@~7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.25.9", "@babel/compat-data@^7.26.0":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.2.tgz#278b6b13664557de95b8f35b90d96785850bb56e"
@@ -374,6 +381,16 @@
   dependencies:
     "@babel/template" "^7.27.1"
     "@babel/types" "^7.27.1"
+
+"@babel/highlight@^7.10.4":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.25.9.tgz#8141ce68fc73757946f983b343f1231f4691acc6"
+  integrity sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.25.9"
+    chalk "^2.4.2"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.13.16", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.25.3", "@babel/parser@^7.25.9", "@babel/parser@^7.26.0", "@babel/parser@^7.26.2":
   version "7.26.2"
@@ -1517,6 +1534,48 @@
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
+
+"@expo/config-plugins@^2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-2.0.4.tgz#955fd70a2aeefbe99ec71cecb1d7ea7b626dc79e"
+  integrity sha512-JGt/X2tFr7H8KBQrKfbGo9hmCubQraMxq5sj3bqDdKmDOLcE1a/EDCP9g0U4GHsa425J8VDIkQUHYz3h3ndEXQ==
+  dependencies:
+    "@expo/config-types" "^41.0.0"
+    "@expo/json-file" "8.2.30"
+    "@expo/plist" "0.0.13"
+    debug "^4.3.1"
+    find-up "~5.0.0"
+    fs-extra "9.0.0"
+    getenv "^1.0.0"
+    glob "7.1.6"
+    resolve-from "^5.0.0"
+    slash "^3.0.0"
+    xcode "^3.0.1"
+    xml2js "^0.4.23"
+
+"@expo/config-types@^41.0.0":
+  version "41.0.0"
+  resolved "https://registry.yarnpkg.com/@expo/config-types/-/config-types-41.0.0.tgz#ffe1444c6c26e0e3a8f7149b4afe486e357536d1"
+  integrity sha512-Ax0pHuY5OQaSrzplOkT9DdpdmNzaVDnq9VySb4Ujq7UJ4U4jriLy8u93W98zunOXpcu0iiKubPsqD6lCiq0pig==
+
+"@expo/json-file@8.2.30":
+  version "8.2.30"
+  resolved "https://registry.yarnpkg.com/@expo/json-file/-/json-file-8.2.30.tgz#bd855b6416b5c3af7e55b43f6761c1e7d2b755b0"
+  integrity sha512-vrgGyPEXBoFI5NY70IegusCSoSVIFV3T3ry4tjJg1MFQKTUlR7E0r+8g8XR6qC705rc2PawaZQjqXMAVtV6s2A==
+  dependencies:
+    "@babel/code-frame" "~7.10.4"
+    fs-extra "9.0.0"
+    json5 "^1.0.1"
+    write-file-atomic "^2.3.0"
+
+"@expo/plist@0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@expo/plist/-/plist-0.0.13.tgz#700a48d9927aa2b0257c613e13454164e7371a96"
+  integrity sha512-zGPSq9OrCn7lWvwLLHLpHUUq2E40KptUFXn53xyZXPViI0k9lbApcR9KlonQZ95C+ELsf0BQ3gRficwK92Ivcw==
+  dependencies:
+    base64-js "^1.2.3"
+    xmlbuilder "^14.0.0"
+    xmldom "~0.5.0"
 
 "@firebase/ai@2.2.1":
   version "2.2.1"
@@ -2689,6 +2748,14 @@
   resolved "https://registry.yarnpkg.com/@react-native-masked-view/masked-view/-/masked-view-0.3.2.tgz#7064533a573e3539ec912f59c1f457371bf49dd9"
   integrity sha512-XwuQoW7/GEgWRMovOQtX3A4PrXhyaZm0lVUiY8qJDvdngjLms9Cpdck6SmGAUNqQwcj2EadHC1HwL0bEyoa/SQ==
 
+"@react-native-voice/voice@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@react-native-voice/voice/-/voice-3.2.4.tgz#a0f9e5986c3c290155dd6e35ed192dab1c453f2c"
+  integrity sha512-4i3IpB/W5VxCI7BQZO5Nr2VB0ecx0SLvkln2Gy29cAQKqgBl+1ZsCwUBChwHlPbmja6vA3tp/+2ADQGwB1OhHg==
+  dependencies:
+    "@expo/config-plugins" "^2.0.0"
+    invariant "^2.2.4"
+
 "@react-native/assets-registry@0.76.3":
   version "0.76.3"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.76.3.tgz#c31e91b6f60fed7b0bfc1af617e3a61218d1ec08"
@@ -3379,6 +3446,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@xmldom/xmldom@^0.9.10":
+  version "0.9.12"
+  resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.9.12.tgz#1f84c07cb95ccf28202299f77b5fd7fc257151e8"
+  integrity sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
@@ -3488,7 +3560,7 @@ ansi-regex@^6.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.1.0.tgz#95ec409c69619d6cb1b8b34f14b660ef28ebd654"
   integrity sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==
 
-ansi-styles@^3.2.0:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -3826,10 +3898,15 @@ base-64@^1.0.0:
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-1.0.0.tgz#09d0f2084e32a3fd08c2475b973788eee6ae8f4a"
   integrity sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==
 
-base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.2.3, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+big-integer@1.6.x:
+  version "1.6.52"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.52.tgz#60a887f3047614a8e1bffe5d7173490a97dc8c85"
+  integrity sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==
 
 binary-extensions@^2.0.0:
   version "2.3.0"
@@ -3854,6 +3931,20 @@ boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
+bplist-creator@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.1.0.tgz#018a2d1b587f769e379ef5519103730f8963ba1e"
+  integrity sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==
+  dependencies:
+    stream-buffers "2.2.x"
+
+bplist-parser@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.3.1.tgz#e1c90b2ca2a9f9474cc72f6862bbf3fee8341fd1"
+  integrity sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==
+  dependencies:
+    big-integer "1.6.x"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -3979,6 +4070,15 @@ caniuse-lite@^1.0.30001669:
   version "1.0.30001686"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001686.tgz#0e04b8d90de8753188e93c9989d56cb19d902670"
   integrity sha512-Y7deg0Aergpa24M3qLC5xjNklnKnhsmSyR/V89dLZ1n0ucJIFNs7PgR2Yfa/Zf6W79SbBicgtGxZr2juHkEUIA==
+
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
 
 chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
@@ -5335,7 +5435,7 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
-find-up@^5.0.0:
+find-up@^5.0.0, find-up@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
   integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
@@ -5451,6 +5551,16 @@ fresh@0.5.2:
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
   integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
 
+fs-extra@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.0.tgz#b6afc31036e247b2466dc99c29ae797d5d4580a3"
+  integrity sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -5540,6 +5650,11 @@ get-symbol-description@^1.0.2:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
 
+getenv@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/getenv/-/getenv-1.0.0.tgz#874f2e7544fbca53c7a4738f37de8605c3fcfc31"
+  integrity sha512-7yetJWqbS9sbn0vIfliPsFgoXMKn/YMF+Wuiog97x+urnSRRRZ7xB+uVkwGKzRgq9CDFfMQnE9ruL5DHv9c6Xg==
+
 git-raw-commits@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-4.0.0.tgz#b212fd2bff9726d27c1283a1157e829490593285"
@@ -5562,6 +5677,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^10.3.10:
   version "10.4.5"
@@ -5657,6 +5784,11 @@ has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -6745,6 +6877,13 @@ json-stable-stringify@^1.0.2:
     jsonify "^0.0.1"
     object-keys "^1.1.1"
 
+json5@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  dependencies:
+    minimist "^1.2.0"
+
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -7445,7 +7584,7 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.6, minimist@^1.2.8:
+minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -8101,6 +8240,15 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+plist@^3.0.5:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.1.1.tgz#fa6099e1e3cf6ea180258ebe6378ea3878c2c841"
+  integrity sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==
+  dependencies:
+    "@xmldom/xmldom" "^0.9.10"
+    base64-js "^1.5.1"
+    xmlbuilder "^15.1.1"
 
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
@@ -8989,6 +9137,11 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
+sax@>=0.6.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.6.1.tgz#4c23cf608c0b693ab54b4b5888e92cfe977b9843"
+  integrity sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==
+
 scheduler@0.24.0-canary-efb381bbf-20230505:
   version "0.24.0-canary-efb381bbf-20230505"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.24.0-canary-efb381bbf-20230505.tgz#5dddc60e29f91cd7f8b983d7ce4a99c2202d178f"
@@ -9141,6 +9294,15 @@ signal-exit@^4.0.1:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
+simple-plist@^1.1.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.3.1.tgz#16e1d8f62c6c9b691b8383127663d834112fb017"
+  integrity sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==
+  dependencies:
+    bplist-creator "0.1.0"
+    bplist-parser "0.3.1"
+    plist "^3.0.5"
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -9264,6 +9426,11 @@ statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+stream-buffers@2.2.x:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
+  integrity sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==
 
 strict-uri-encode@^2.0.0:
   version "2.0.0"
@@ -9448,6 +9615,13 @@ superstruct@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/superstruct/-/superstruct-2.0.2.tgz#3f6d32fbdc11c357deff127d591a39b996300c54"
   integrity sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==
+
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
 
 supports-color@^7.1.0:
   version "7.2.0"
@@ -9798,6 +9972,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
+
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
@@ -9862,6 +10041,11 @@ uuid@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
   integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 uuid@^9.0.0:
   version "9.0.1"
@@ -10090,6 +10274,42 @@ ws@^7, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+xcode@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-3.0.1.tgz#3efb62aac641ab2c702458f9a0302696146aa53c"
+  integrity sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==
+  dependencies:
+    simple-plist "^1.1.0"
+    uuid "^7.0.3"
+
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-14.0.0.tgz#876b5aec4f05ffd5feb97b0a871c855d16fbeb8c"
+  integrity sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg==
+
+xmlbuilder@^15.1.1:
+  version "15.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-15.1.1.tgz#9dcdce49eea66d8d10b42cae94a79c3c8d0c2ec5"
+  integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xmldom@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
## Speech-to-text prompt input

Adds voice dictation to the prompt input using the native OS speech recognizer. No model download, no added app size.

### Behavior
- A mic button appears in the action row when the prompt is empty.
- Tap to start listening. First use prompts for microphone permission.
- Words stream into the prompt as you speak. The recognizer's corrections show up live.
- A waveform driven by real mic level replaces the mic icon while recording, so you can see it is hearing you.
- Recording stops on OS-detected silence or a second tap.
- Nothing is auto-submitted. The transcript sits in the input for editing like typed text.

### Implementation
- `@react-native-voice/voice` wraps Android `SpeechRecognizer` and iOS `SFSpeechRecognizer`.
- `useSpeechToText` handles permission, start/stop, partial and final results, and exposes mic level as a reanimated shared value so the waveform animates on the UI thread with no React re-renders per sample.
- `VoiceRecordingIndicator` is a four-bar waveform with per-bar gain, driven by that shared value.
- `ActionMenu` now has four states: stop generating, recording waveform, mic, send.

### Library patch
`@react-native-voice/voice` has not been updated for the New Architecture. Two fixes via `patch-package`:

1. **Null native module.** The Android module registers as `RCTVoice` while JS reads `NativeModules.Voice`. The old bridge stripped the `RCT` prefix natively; the New Architecture interop layer keys legacy modules by exact `getName()`, so the module resolved to null. Renamed to `Voice`, which is correct under both architectures.
2. **Manifest merge failure.** It declared `com.android.support:appcompat-v7` but only imports `androidx.annotation`. The legacy dep pulled in `support-compat` and collided with `androidx.core`. Swapped for `androidx.annotation` so we do not need Jetifier.

### Native config
- Android: `RECORD_AUDIO` permission.
- iOS: `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription`.

### Testing
- [x] Android debug build succeeds without Jetifier
- [x] Android: dictation streams into prompt, waveform reacts, stops on silence and on tap

### Notes
- Dictation replaces the prompt wholesale on each interim result. Safe today because the mic only appears when the prompt is empty. Appending to typed text would need the hook to capture a prefix at start..